### PR TITLE
ci: release 工作流增加 concurrency 防止重复运行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
             - "v*.*.*"
     workflow_dispatch:
 
+# 同一个 tag 只允许一个 release 流程运行，后触发的会自动取消前一个
+concurrency:
+    group: release-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     # 先创建 draft release，后续 job 往这个 release 上传 assets
     create-release:


### PR DESCRIPTION
## Summary
- release 工作流增加 `concurrency` 配置，同一个 tag 只允许一个 release 流程运行
- 后触发的 run 会自动取消前一个，防止 tag 移动时多个 run 互相干扰导致 release 卡死

## Context
v2.5.0 部署失败的根因：tag 被多次移动，多个 release workflow 并行运行，后一个把已发布的 release 改回 draft，然后自己卡死

Made with [Cursor](https://cursor.com)