### PR TITLE
fix: 修复文本对比编辑器布局问题，优化发布流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # 构建发布平台适配文件
-# 流程：push tag → 创建 draft release → 各 job 并行构建上传 → 最后自动发布
+# 流程：push tag → 创建 draft release → 各 job 并行构建上传 → 手动到 GitHub Releases 发布
 name: release-ctool-adapter
 on:
     push:
@@ -166,32 +166,3 @@ jobs:
                   draft: true
                   files: |
                       ${{ steps.get_release_files.outputs.files }}
-
-    # 所有构建完成后，将 draft 发布为正式 release
-    publish-release:
-        needs: [browser-extensions, tauri-desktop]
-        runs-on: ubuntu-latest
-        steps:
-            - name: Publish Release
-              uses: actions/github-script@v7
-              with:
-                  script: |
-                      // 查找当前 tag 对应的 draft release
-                      const tag = context.ref.replace('refs/tags/', '');
-                      const releases = await github.rest.repos.listReleases({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                      });
-                      const draft = releases.data.find(r => r.tag_name === tag && r.draft);
-                      if (!draft) {
-                          core.setFailed(`未找到 tag ${tag} 对应的 draft release`);
-                          return;
-                      }
-                      // 将 draft 改为正式发布
-                      await github.rest.repos.updateRelease({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          release_id: draft.id,
-                          draft: false,
-                      });
-                      core.info(`Release ${tag} 已发布: ${draft.html_url}`);

--- a/packages/ctool-core/src/components/editor/Diff.vue
+++ b/packages/ctool-core/src/components/editor/Diff.vue
@@ -131,7 +131,7 @@ const create = async (element: HTMLElement) => {
             lineNumbers: lineNumbers.value ? "on" : "off",
             wordWrap: lineWrapping.value ? "on" : "off",
             minimap: { enabled: false },
-            automaticLayout: false,
+            automaticLayout: true,
             originalEditable: true,
             scrollBeyondLastLine: false,
             renderSideBySide: !inline.value,


### PR DESCRIPTION
## Summary
- **Diff 编辑器布局修复**：`automaticLayout` 从 `false` 改为 `true`，修复右侧输入框在正常屏幕宽度下不可见的问题（上游遗留 bug，Editor.vue 一直是 `true`）
- **发布流程优化**：移除 `publish-release` job 的自动发布，构建完成后 release 停在 draft 状态，需手动到 GitHub Releases 验证并发布

## Test plan
- [ ] 本地 `pnpm run dev` 打开文本对比工具，确认左右两侧编辑器均正常显示
- [ ] 调整窗口大小，确认编辑器自动适应布局

Made with [Cursor](https://cursor.com)