### PR TITLE
ci: GitHub Pages 部署改用 github_token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,5 +49,5 @@ jobs:
             - name: Deploy web to gh-pages
               uses: peaceiris/actions-gh-pages@v4
               with:
-                  deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: ./packages/ctool-core/dist


### PR DESCRIPTION
## Summary
- `build.yml` 的 gh-pages 部署从 `deploy_key` 改为 `github_token`
- `GITHUB_TOKEN` 是 Actions 内置的，不需要额外配置 SSH 密钥
- 解决 GitHub Pages 一直没有实际部署成功的问题

Made with [Cursor](https://cursor.com)