### PR TITLE
feat: JSON Transform（JS 表达式转换）

### DIFF
--- a/packages/ctool-core/src/tools/json/Json.vue
+++ b/packages/ctool-core/src/tools/json/Json.vue
@@ -37,6 +37,13 @@
                     v-model="action.current.option.schema"
                     @success="() => action.save()"
                 />
+                <Transform
+                    v-if="action.current.expand_type === 'transform'"
+                    :height="height"
+                    :json="inputSerialize"
+                    v-model="action.current.option.transform"
+                    @success="() => action.save()"
+                />
             </div>
         </HeightResize>
         <Display position="top-right" class="ctool-page-option" style="margin-top: 5px">
@@ -55,6 +62,7 @@
                     { label: $t(`json_object`), name: `object` },
                     { label: $t(`json_from`), name: `from` },
                     { label: $t(`json_to`), name: `to` },
+                    { label: $t(`json_transform`), name: `transform` },
                 ]"
             >
                 <Align>
@@ -158,6 +166,7 @@ import { useAction, initialize } from "@/store/action";
 import { tabOptions, actionType, TabsType, pathLists } from "./define";
 import { createSerializeInput, createSerializeOutput } from "@/components/serialize";
 import Schema from "./Schema.vue";
+import Transform from "./Transform.vue";
 import { serializeInputEncoderLists, serializeOutputEncoderLists } from "@/types";
 import Path from "./Path.vue";
 import Serialize from "@/helper/serialize";
@@ -192,6 +201,9 @@ const action = useAction(
                 from: createSerializeInput("csv"),
                 to: createSerializeOutput("xml"),
                 to_object: getToObjectOption(""),
+                transform: {
+                    expression: "",
+                },
             },
         },
         { paste: false },
@@ -207,7 +219,7 @@ const size: ComponentSizeType = "default";
 // 布局
 const layoutStyle = $computed(() => {
     const css: StyleValue = {};
-    if (["from", "object", "to", "path", "json_schema"].includes(action.current.expand_type)) {
+    if (["from", "object", "to", "path", "json_schema", "transform"].includes(action.current.expand_type)) {
         css.display = "grid";
         css.gridTemplateColumns = "repeat(2, minmax(0, 1fr))";
         css.columnGap = "5px";
@@ -363,7 +375,7 @@ const setExpandType = value => {
 watch(
     () => action.current.tabs,
     tabs => {
-        setExpandType(["from", "to", "path"].includes(tabs) ? tabs : "");
+        setExpandType(["from", "to", "path", "transform"].includes(tabs) ? tabs : "");
     },
 );
 </script>

--- a/packages/ctool-core/src/tools/json/Transform.vue
+++ b/packages/ctool-core/src/tools/json/Transform.vue
@@ -1,0 +1,147 @@
+<template>
+    <div style="display: flex; flex-direction: column; height: 100%;">
+        <!-- 表达式编辑器 -->
+        <Align direction="vertical" class="ctool-json-transform-header" :bottom="'default'">
+            <Display position="right-center">
+                <Input
+                    v-model="option.expression"
+                    :placeholder="$t('json_transform_placeholder')"
+                    :label="$t('json_transform')"
+                />
+                <template #extra>
+                    <Align>
+                        <Dropdown
+                            :size="'small'"
+                            :options="presetExpressions"
+                            :placeholder="$t('json_transform_preset')"
+                            @select="value => (option.expression = value)"
+                        />
+                    </Align>
+                </template>
+            </Display>
+        </Align>
+        <!-- 结果输出 -->
+        <HeightResize @resize="resize" :father-height="height" :append="['.ctool-json-transform-header']">
+            <Editor
+                :model-value="output"
+                :placeholder="`${$t('json_transform')} ${$t('main_ui_output')}`"
+                lang="json"
+                :height="`${editorHeight}px`"
+            />
+        </HeightResize>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import {PropType, watch} from "vue";
+import {isObject} from "lodash";
+import _ from "lodash";
+import formatter from "../code/formatter";
+import Serialize from "@/helper/serialize";
+
+export type TransformOptionType = {
+    expression: string;
+}
+
+const props = defineProps({
+    modelValue: {
+        type: Object as PropType<TransformOptionType>,
+        default: () => {
+            return {
+                expression: "",
+            }
+        }
+    },
+    json: {
+        type: Object as PropType<Serialize>,
+        default: () => {
+            return Serialize.empty()
+        }
+    },
+    height: {
+        type: Number,
+        default: 0
+    },
+})
+const emit = defineEmits<{ (e: 'update:modelValue', modelValue: TransformOptionType): void, (e: 'success'): void }>()
+
+const option: TransformOptionType = $computed({
+    get: () => props.modelValue,
+    set: (value) => emit('update:modelValue', value)
+})
+
+// 预设常用表达式
+const presetExpressions = [
+    {label: "Object.keys(data)", value: "Object.keys(data)"},
+    {label: "Object.values(data)", value: "Object.values(data)"},
+    {label: "_.map(data, 'key')", value: "_.map(data, 'key')"},
+    {label: "_.filter(data, {key: 'value'})", value: "_.filter(data, {key: 'value'})"},
+    {label: "_.groupBy(data, 'key')", value: "_.groupBy(data, 'key')"},
+    {label: "_.sortBy(data, 'key')", value: "_.sortBy(data, 'key')"},
+    {label: "_.uniqBy(data, 'key')", value: "_.uniqBy(data, 'key')"},
+    {label: "_.pick(data, ['key1', 'key2'])", value: "_.pick(data, ['key1', 'key2'])"},
+    {label: "_.omit(data, ['key'])", value: "_.omit(data, ['key'])"},
+    {label: "data.length", value: "data.length"},
+]
+
+/**
+ * 执行用户表达式
+ * data: 输入的 JSON 数据
+ * _: lodash 工具库
+ */
+const executeTransform = (data: any, expression: string): any => {
+    // 使用 new Function 在隔离作用域中执行，避免污染全局
+    const fn = new Function('data', '_', `"use strict"; return (${expression})`)
+    return fn(data, _)
+}
+
+let output = $ref("")
+
+// debounce 定时器
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+watch(() => {
+    return {
+        json: props.json,
+        expression: option.expression,
+    }
+}, ({json, expression}) => {
+    // 清除上一次的定时器
+    if (debounceTimer) {
+        clearTimeout(debounceTimer)
+    }
+
+    // 空输入直接清空
+    if (json.isEmpty() || !expression || expression.trim() === "") {
+        output = ""
+        return
+    }
+    if (json.isError()) {
+        output = json.error()
+        return
+    }
+
+    // debounce 300ms，避免输入时频繁执行
+    debounceTimer = setTimeout(async () => {
+        try {
+            const data = json.content()
+            const result = executeTransform(data, expression.trim())
+            if (result === undefined || result === null) {
+                output = String(result)
+            } else if (isObject(result)) {
+                output = await formatter.simple('json', 'beautify', result)
+            } else {
+                output = String(result)
+            }
+            emit('success')
+        } catch (e) {
+            output = $error(e)
+        }
+    }, 300)
+}, {immediate: true, deep: true})
+
+let editorHeight = $ref(100)
+const resize = (height) => {
+    editorHeight = height
+}
+</script>

--- a/packages/ctool-core/src/tools/json/define.ts
+++ b/packages/ctool-core/src/tools/json/define.ts
@@ -1,5 +1,6 @@
 import { SerializeInput, SerializeOutput } from "@/components/serialize";
 import { Option as toObjectOption } from "./toObject";
+import { TransformOptionType } from "./Transform.vue";
 //=======
 const tabsMap = [
     { label: $t("code_indent_width_null"), value: 0 },
@@ -27,6 +28,7 @@ export type SchemaOptionType = {
     option: Record<string, any>;
 };
 
+
 //=======
 export type actionType = {
     input: string;
@@ -42,5 +44,6 @@ export type actionType = {
         path: PathOptionType;
         schema: SchemaOptionType;
         to_object: toObjectOption;
+        transform: TransformOptionType;
     };
 };

--- a/packages/ctool-core/src/tools/json/i18n/en.json5
+++ b/packages/ctool-core/src/tools/json/i18n/en.json5
@@ -21,4 +21,8 @@
     "json_path": "JSONPath",
     "jmes_path": "JMESPath",
     "line_info": "Length",
+    // Transform (JS expression)
+    "transform": "Transform",
+    "transform_placeholder": "JS expression, e.g. _.groupBy(data, 'key')",
+    "transform_preset": "Presets",
 }

--- a/packages/ctool-core/src/tools/json/i18n/zh_CN.json5
+++ b/packages/ctool-core/src/tools/json/i18n/zh_CN.json5
@@ -21,4 +21,8 @@
     "json_path": "JSONPath",
     "jmes_path": "JMESPath",
     "line_info": "长度",
+    // Transform（JS 表达式转换）
+    "transform": "转换",
+    "transform_placeholder": "输入 JS 表达式，如 _.groupBy(data, 'key')",
+    "transform_preset": "常用表达式",
 }


### PR DESCRIPTION
## Summary
- JSON 工具新增 Transform Tab，支持用 JavaScript + lodash 表达式对 JSON 数据做变换
- 内置 10 个常用表达式预设（groupBy、sortBy、filter、pick、omit 等）
- 300ms debounce 避免输入时高频执行
- 左右分栏布局，左侧输入 JSON，右侧实时展示转换结果

## Test plan
- [ ] 输入 JSON 数组，使用 `_.sortBy(data, 'key')` 验证排序
- [ ] 使用 `_.filter(data, {key: 'value'})` 验证筛选
- [ ] 使用 `Object.keys(data)` 验证原生 JS 表达式
- [ ] 验证常用表达式下拉预设
- [ ] 验证错误表达式时的错误提示
- [ ] 验证空输入时不执行

Ref: https://github.com/baiy/Ctool/issues/388

Made with [Cursor](https://cursor.com)