### PR TITLE
chore: 添加 engines 字段约束 Node/pnpm 版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "repository": "https://github.com/nidhogg1024/Ctool",
     "author": "nidhogg1024",
     "license": "MIT",
+    "engines": {
+        "node": ">=20",
+        "pnpm": ">=10"
+    },
     "scripts": {
         "initialize": "pnpm --filter ctool-config run build && pnpm --filter ctool-adapter-base run build && pnpm -r run adapter-build",
         "check": "pnpm run initialize && pnpm --filter ctool-core run check",


### PR DESCRIPTION
## Summary

- package.json 添加 `engines: { node: ">=20", pnpm: ">=10" }`
- 避免贡献者使用不兼容版本导致构建问题

## Test plan

- [x] `pnpm install` 正常通过


Made with [Cursor](https://cursor.com)