### PR TITLE
fix: 修复 uTools 路由跳转 + 改名 Ctool Plus

### DIFF
--- a/packages/ctool-adapter/utools/resources/plugin.json
+++ b/packages/ctool-adapter/utools/resources/plugin.json
@@ -1,8 +1,8 @@
 {
-    "pluginName": "Ctool",
-    "description": "Ctool 程序开发常用工具",
-    "author": "baiy",
-    "homepage": "https://github.com/baiy/Ctool",
+    "pluginName": "Ctool Plus",
+    "description": "程序开发常用工具（增强版）— 加密/编解码/JSON/时间戳/正则/IP计算等 70+ 工具",
+    "author": "nidhogg1024",
+    "homepage": "https://github.com/nidhogg1024/Ctool",
     "main": "tool.html",
     "version": "##version##",
     "logo": "icon/icon_utools.png",

--- a/packages/ctool-adapter/utools/src/index.ts
+++ b/packages/ctool-adapter/utools/src/index.ts
@@ -72,13 +72,13 @@ export const runtime = new (class implements PlatformRuntime {
             // 输入框数据写入临时存储
             if (["over", "regex"].includes(type) && payload !== "") {
                 initializer.storage().setNoVersion("_temp_input_storage", payload, 10);
-                //添加随机数 防止页面不刷新
-                query["_t"] = `${Math.random()}`;
             }
             // 设置功能搜索关键字
             if (type === "text" && payload !== "") {
                 query.keyword = payload;
             }
+            // 添加随机数防止页面不刷新（所有类型都需要，否则目标路由相同时不会触发刷新）
+            query["_t"] = `${Math.random()}`;
             initializer.push(feature.getRouter(), query);
         });
     }

--- a/packages/ctool-adapter/utools/src/release.ts
+++ b/packages/ctool-adapter/utools/src/release.ts
@@ -30,8 +30,8 @@ type UtoolsFeature = {
 
 const utoolsFeature: Record<string, any>[] = [{
     "code": "ctool",
-    "explain": "程序开发常用工具",
-    "cmds": ['ctool', '程序开发常用工具']
+    "explain": "程序开发常用工具（增强版）",
+    "cmds": ['ctool', 'ctool plus', '程序开发常用工具']
 }];
 tools.forEach(tool => {
     tool.features.forEach(feature => {

--- a/packages/ctool-core/src/helper/platform/runtime.ts
+++ b/packages/ctool-core/src/helper/platform/runtime.ts
@@ -42,7 +42,11 @@ export default class {
                 return storage;
             },
             push(path: string, query: Record<string, string | number> = {}) {
-                void router.push({ path, query });
+                // 等待路由就绪后再跳转（uTools 冷启动时 router 可能未 ready）
+                // 使用 replace 避免路由历史堆积导致二次进入回到错误页面
+                router.isReady().then(() => {
+                    void router.replace({ path, query });
+                });
             },
         };
 


### PR DESCRIPTION
## Summary

- **修复 uTools 路由跳转失败**：借鉴 [lk-eternal/Ctool](https://github.com/lk-eternal/Ctool) 的修复方案
  - `router.push` → `router.isReady().then(router.replace)`，解决冷启动不跳转
  - 随机数 `_t` 参数从仅 over/regex 类型扩展到所有跳转，解决二次进入不刷新
  - `push` → `replace` 避免路由历史堆积
- **插件改名 Ctool Plus**：更新 pluginName、description、author、homepage，准备发布到 uTools 插件市场

Fixes: baiy/Ctool#304 baiy/Ctool#385 baiy/Ctool#396

## Test plan

- [ ] uTools 中通过关键词搜索进入工具，验证首次跳转正常
- [ ] 连续切换不同工具关键词，验证每次都跳转到正确工具
- [ ] 验证构建产物 plugin.json 中 pluginName 为 "Ctool Plus"

Made with [Cursor](https://cursor.com)