### PR TITLE
fix: uTools 插件白屏 + 分类标签溢出修复

### DIFF
--- a/packages/ctool-core/src/block/layout/complex/Header.vue
+++ b/packages/ctool-core/src/block/layout/complex/Header.vue
@@ -141,6 +141,16 @@ watch(() => {
     display: inline-flex;
     align-items: center;
     padding-left: 5px;
+    /* 分类标签超出时横向可滚动（uTools 等固定宽度环境需要） */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    flex-shrink: 1;
+    min-width: 0;
+}
+.ctool-header-top-left::-webkit-scrollbar {
+    display: none;
 }
 
 .ctool-header-top-right {
@@ -149,13 +159,14 @@ watch(() => {
 }
 
 .ctool-header-category {
-    font-size: 14px;
+    font-size: 13px;
     display: inline-flex;
     height: 100%;
     align-items: center;
-    padding: 0 .85rem;
+    padding: 0 .5rem;
     cursor: pointer;
     white-space: nowrap;
+    flex-shrink: 0;
 }
 [data-locale="en"] .ctool-header-category{
     padding: 0 .3rem;
@@ -222,19 +233,6 @@ watch(() => {
     .ctool-header-top {
         height: 42px;
         padding: 0 8px;
-    }
-
-    /* 分类标签区域：横向可滚动，不截断 */
-    .ctool-header-top-left {
-        overflow-x: auto;
-        overflow-y: hidden;
-        scrollbar-width: none;
-        -ms-overflow-style: none;
-        flex-shrink: 1;
-        min-width: 0;
-    }
-    .ctool-header-top-left::-webkit-scrollbar {
-        display: none;
     }
 
     .ctool-header-category {


### PR DESCRIPTION
## Summary

- **修复 uTools 白屏**：Vite 6 构建输出的 `crossorigin` 属性在 `file://` 协议下触发 CORS，release 脚本中后处理去除
- **移除 development 字段**：`plugin.json` 的 `development.main` 指向 localhost，生产包中不应包含
- **分类标签溢出**：默认 `overflow-x: auto` + 间距从 0.85rem 缩至 0.5rem，适配 uTools 800px 固定宽度

## Test plan

- [x] uTools 本地加载插件，界面正常渲染（不再白屏）
- [x] 7 个分类标签全部可见
- [x] lint / test / check 全部通过
- [x] CI 构建产物 plugin.json 无 development 字段，HTML 无 crossorigin

Made with [Cursor](https://cursor.com)