### PR TITLE
fix: derive release adapter version from tag

### DIFF
--- a/packages/ctool-adapter/base/src/index.ts
+++ b/packages/ctool-adapter/base/src/index.ts
@@ -1,5 +1,6 @@
 import {join} from "path";
 import {copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync} from "fs";
+import {execSync} from "child_process";
 
 export const getPath = (path = "") => {
     return join(__dirname, '../../../../', path)
@@ -60,6 +61,19 @@ export const getAdditionData = (): Record<string, any> => {
     return JSON.parse(readFileSync(getPath('packages/ctool-core/dist/ctool.addition.json')).toString())
 }
 
+const getGitVersion = (): string => {
+    const refName = process.env.GITHUB_REF_NAME || "";
+    if (/^v?\d+\.\d+\.\d+(?:[-+].*)?$/.test(refName)) {
+        return refName.replace(/^v/, "");
+    }
+    try {
+        const tag = execSync("git describe --tags --abbrev=0", {cwd: getPath(), encoding: "utf-8"}).trim();
+        return tag.replace(/^v/, "");
+    } catch {
+        return "";
+    }
+}
+
 export const version = (): string => {
-    return getRootPackageJson()['version'] || ""
+    return getGitVersion() || getRootPackageJson()['version'] || ""
 }


### PR DESCRIPTION
## 变更内容

- 发布包版本号优先读取 GitHub tag/ref，例如 v2.9.1 会写入 2.9.1。
- 无 tag 环境继续 fallback 到 root package.json version。

## 验证

- pnpm --filter ctool-adapter-base run build
- pnpm run lint
- GITHUB_REF_NAME=v2.9.1 node -e "const {version}=require(\x27./packages/ctool-adapter/base/dist/index.js\x27); console.log(version())"
