### PR TITLE
fix: 发布仅接受稳定版本 Tag

### DIFF
--- a/packages/ctool-adapter/base/src/version.ts
+++ b/packages/ctool-adapter/base/src/version.ts
@@ -1,7 +1,6 @@
 import {execFileSync} from "child_process";
 
 const STABLE_VERSION = /^v?((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$/;
-const SHA_RELEASE_TAG = /^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))-[0-9a-f]{7}$/;
 
 export interface VersionInputs {
     ctoolVersion?: string;
@@ -15,21 +14,16 @@ const stableVersion = (value = ""): string => {
     return matched && matched.split(".").every(part => Number(part) <= 65535) ? matched : "";
 }
 
-const releaseTagVersion = (value = ""): string => {
-    const matched = value.trim().match(SHA_RELEASE_TAG)?.[1] || "";
-    return stableVersion(value) || (matched && matched.split(".").every(part => Number(part) <= 65535) ? matched : "");
-}
-
 const resolvedStableVersion = (inputs: VersionInputs): string => {
     if (inputs.ctoolVersion !== undefined && !stableVersion(inputs.ctoolVersion)) {
         throw new Error(`invalid CTOOL_VERSION: ${inputs.ctoolVersion || "<empty>"}`);
     }
-    const explicit = stableVersion(inputs.ctoolVersion) || releaseTagVersion(inputs.githubRefName);
+    const explicit = stableVersion(inputs.ctoolVersion) || stableVersion(inputs.githubRefName);
     if (explicit) {
         return explicit;
     }
     if (inputs.cleanHead) {
-        const tagVersion = releaseTagVersion(inputs.exactTag);
+        const tagVersion = stableVersion(inputs.exactTag);
         if (tagVersion) {
             return tagVersion;
         }

--- a/packages/ctool-core/src/versionRelease.test.ts
+++ b/packages/ctool-core/src/versionRelease.test.ts
@@ -36,11 +36,6 @@ describe("release version resolution", () => {
         expect(resolveReleaseVersion({githubRefName: "v3.1.4", exactTag: "", cleanHead: false})).toBe("3.1.4");
     });
 
-    it("derives a stable artifact version from a SHA-suffixed release tag", () => {
-        expect(resolveReleaseVersion({githubRefName: "v3.1.4-a1b2c3d", exactTag: "", cleanHead: false})).toBe("3.1.4");
-        expect(resolveReleaseVersion({exactTag: "v3.1.4-a1b2c3d", cleanHead: true})).toBe("3.1.4");
-    });
-
     it("uses only a stable exact tag on a clean HEAD", () => {
         expect(resolveReleaseVersion({exactTag: "v2.9.1", cleanHead: true})).toBe("2.9.1");
         expect(() => resolveReleaseVersion({exactTag: "v2.9.1", cleanHead: false})).toThrow("release version requires");
@@ -49,17 +44,14 @@ describe("release version resolution", () => {
     it("does not publish prerelease, branch, or ancestor-tag values", () => {
         expect(() => resolveReleaseVersion({ctoolVersion: "2.10.0-beta.1", githubRefName: "main", exactTag: "", cleanHead: true})).toThrow("invalid CTOOL_VERSION");
         expect(() => resolveReleaseVersion({githubRefName: "v2.10.0-beta.1", exactTag: "", cleanHead: true})).toThrow("release version requires");
-        expect(() => resolveReleaseVersion({githubRefName: "v2.10.0-A1B2C3D", exactTag: "", cleanHead: true})).toThrow("release version requires");
-        expect(() => resolveReleaseVersion({githubRefName: "v2.10.0-a1b2c3", exactTag: "", cleanHead: true})).toThrow("release version requires");
+        expect(() => resolveReleaseVersion({githubRefName: "v2.10.0-a1b2c3d", exactTag: "", cleanHead: true})).toThrow("release version requires");
         expect(() => resolveReleaseVersion({githubRefName: "feature/version", exactTag: "", cleanHead: true})).toThrow("release version requires");
         expect(() => resolveReleaseVersion({exactTag: "", cleanHead: true})).toThrow("release version requires");
     });
 
     it("rejects version segments that browser manifests cannot publish", () => {
         expect(resolveReleaseVersion({ctoolVersion: "65535.0.1", cleanHead: false})).toBe("65535.0.1");
-        expect(resolveReleaseVersion({githubRefName: "v65535.0.1-a1b2c3d", cleanHead: false})).toBe("65535.0.1");
         expect(() => resolveReleaseVersion({ctoolVersion: "65536.0.1", cleanHead: false})).toThrow("invalid CTOOL_VERSION");
-        expect(() => resolveReleaseVersion({githubRefName: "v65536.0.1-a1b2c3d", cleanHead: false})).toThrow("release version requires");
         expect(() => resolveReleaseVersion({ctoolVersion: "02.9.1", cleanHead: false})).toThrow("invalid CTOOL_VERSION");
     });
 


### PR DESCRIPTION
## 变更说明

- 删除 `vX.Y.Z-<Commit SHA>` Tag 的兼容解析。
- 发布版本只接受个人项目现有约定的稳定 Tag：`vX.Y.Z`。
- 继续拒绝 beta/rc、分支名、祖先 Tag、前导零和超出浏览器清单范围的版本号。

## 主要改动

- 版本解析统一复用稳定版本校验，不保留 Hash Tag 的平行路径。
- 增加回归断言，确认 `v2.10.0` 可发布，`v2.10.0-a1b2c3d` 会被发布门禁拒绝。

## 测试

- `pnpm --filter ctool-core exec vitest run src/versionRelease.test.ts`：18 项通过。
- `pnpm test`：21 个测试文件、323 项通过。
- `pnpm check`：通过。
- `pnpm build`：通过。
- `pnpm lint`：0 error，188 条仓库既有 warning。
- `actionlint v1.7.12 .github/workflows/release.yml`：通过。
- `git diff --check`：通过。
